### PR TITLE
Updated Comp2024 to use CommandXBoxController classes

### DIFF
--- a/Comp2024/src/main/java/frc/robot/Constants.java
+++ b/Comp2024/src/main/java/frc/robot/Constants.java
@@ -93,7 +93,8 @@ public class Constants
     public static final int    kCANID_CANdle         = 0;
 
     // Digital I/Os
-    // public static final int    kDIO_ExampleDetect = 2;
+    public static final int    kDIO0_NoteInIntake    = 0;
+    public static final int    kDIO1_NoteInFeeder    = 1;
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/Comp2024/src/main/java/frc/robot/Constants.java
+++ b/Comp2024/src/main/java/frc/robot/Constants.java
@@ -27,9 +27,6 @@ import frc.robot.lib.util.SwerveModuleConstants;
  */
 public class Constants
 {
-  // Toggles constants between comp robot and practice robot (named "beta")
-  public static boolean      isComp;
-
   // bot serial nums
   public static final String kCompSN               = "03238074";
   public static final String kBetaSN               = "03260A3A";
@@ -102,7 +99,7 @@ public class Constants
   /////////////////////////////////////////////////////////////////////////////
   public static final class Falcon500
   {
-    public static int          kMaxRPM     = 6380; // free speed for Falcon 500 motor
+    public static final int    kMaxRPM     = 6380; // free speed for Falcon 500 motor
     public static final double kEncoderCPR = 2048; // CPR is from Falcon 500 Manual
   }
 
@@ -175,8 +172,9 @@ public class Constants
     /* Front Left Module - Module 0 */
     public static final class Mod0
     {
-      public static final double betaAngleOffset = 0.0;
-      public static final double compAngleOffset = 0.043945;
+      private static final boolean isComp          = true;  // TODO: needs to be fixed if we keep these module definitions
+      public static final double   betaAngleOffset = 0.0;
+      public static final double   compAngleOffset = 0.043945;
 
       public static SwerveModuleConstants SwerveModuleConstants( )
       {
@@ -188,8 +186,9 @@ public class Constants
     /* Front Right Module - Module 1 */
     public static final class Mod1
     {
-      public static final double betaAngleOffset = 0.0;
-      public static final double compAngleOffset = -0.331787;
+      private static final boolean isComp          = true;  // TODO: needs to be fixed if we keep these module definitions
+      public static final double   betaAngleOffset = 0.0;
+      public static final double   compAngleOffset = -0.331787;
 
       public static SwerveModuleConstants SwerveModuleConstants( )
       {
@@ -201,8 +200,9 @@ public class Constants
     /* Back Left Module - Module 2 */
     public static final class Mod2
     {
-      public static final double betaAngleOffset = 0.0;
-      public static final double compAngleOffset = 0.272949;
+      private static final boolean isComp          = true;  // TODO: needs to be fixed if we keep these module definitions
+      public static final double   betaAngleOffset = 0.0;
+      public static final double   compAngleOffset = 0.272949;
 
       public static SwerveModuleConstants SwerveModuleConstants( )
       {
@@ -214,8 +214,9 @@ public class Constants
     /* Back Right Module - Module 3 */
     public static final class Mod3
     {
-      public static final double betaAngleOffset = 0.0;
-      public static final double compAngleOffset = 0.25836;
+      private static final boolean isComp          = true;  // TODO: needs to be fixed if we keep these module definitions
+      public static final double   betaAngleOffset = 0.0;
+      public static final double   compAngleOffset = 0.25836;
 
       public static SwerveModuleConstants SwerveModuleConstants( )
       {

--- a/Comp2024/src/main/java/frc/robot/Robot.java
+++ b/Comp2024/src/main/java/frc/robot/Robot.java
@@ -24,7 +24,8 @@ import frc.robot.lib.util.LimelightHelpers;
  */
 public class Robot extends TimedRobot
 {
-  private final boolean      UseLimelight    = false;
+  private final boolean      m_useLimelight  = false;
+  public boolean             m_isComp        = false;
 
   private RobotContainer     m_robotContainer;
   private Command            m_autonomousCommand;
@@ -54,12 +55,12 @@ public class Robot extends TimedRobot
       robotName = "SIMULATION";
     else if (serialNum.equals(Constants.kCompSN))
     {
-      Constants.isComp = true;
+      m_isComp = true;
       robotName = "COMPETITION (A)";
     }
     else if (serialNum.equals(Constants.kBetaSN))
     {
-      Constants.isComp = false;
+      m_isComp = false;
       robotName = "PRACTICE (B)";
     }
     DataLogManager.log(String.format("robotInit: Detected the %s robot! ", robotName));
@@ -102,7 +103,7 @@ public class Robot extends TimedRobot
     // for anything in the Command-based framework to work.
     CommandScheduler.getInstance( ).run( );
 
-    if (UseLimelight)
+    if (m_useLimelight)
     {
       var lastResult = LimelightHelpers.getLatestResults("limelight").targetingResults;
 

--- a/Comp2024/src/main/java/frc/robot/Robot.java
+++ b/Comp2024/src/main/java/frc/robot/Robot.java
@@ -10,7 +10,6 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.robot.lib.util.CTREConfigs5;
@@ -25,12 +24,12 @@ import frc.robot.lib.util.LimelightHelpers;
  */
 public class Robot extends TimedRobot
 {
+  private final boolean      UseLimelight    = false;
+
   private RobotContainer     m_robotContainer;
   private Command            m_autonomousCommand;
 
   private boolean            m_faultsCleared = false;
-
-  private final boolean      UseLimelight    = false;
 
   public static CTREConfigs5 ctreConfigs5;
   public static CTREConfigs6 ctreConfigs6;
@@ -74,11 +73,8 @@ public class Robot extends TimedRobot
 
     m_robotContainer.drivetrain.getDaqThread( ).setThreadPriority(99);
 
-    LiveWindow.disableAllTelemetry( );
-
     CommandScheduler.getInstance( ).onCommandInitialize(cmd -> DataLogManager.log(String.format("%s: Init", cmd.getName( ))));
-    CommandScheduler.getInstance( )
-        .onCommandInterrupt(cmd -> DataLogManager.log(String.format("%s: Interrupted", cmd.getName( ))));
+    CommandScheduler.getInstance( ).onCommandInterrupt(cmd -> DataLogManager.log(String.format("%s: Interrupt", cmd.getName( ))));
     CommandScheduler.getInstance( ).onCommandFinish(cmd -> DataLogManager.log(String.format("%s: End", cmd.getName( ))));
 
     PortForwarder.add(5800, "limelight.local", 5800);

--- a/Comp2024/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2024/src/main/java/frc/robot/RobotContainer.java
@@ -37,7 +37,7 @@ import frc.robot.subsystems.Telemetry;
 public class RobotContainer
 {
   private static RobotContainer                m_instance;
-  private final boolean                        macOSXSim       = true;
+  private final boolean                        m_macOSXSim     = true;
 
   // Joysticks
   private final CommandXboxController          m_driverPad     = new CommandXboxController(Constants.kDriverPadPort);
@@ -207,7 +207,7 @@ public class RobotContainer
    */
   private void initDefaultCommands( )
   {
-    if (!macOSXSim)
+    if (!m_macOSXSim)
       drivetrain.setDefaultCommand( // Drivetrain will execute this command periodically
           drivetrain.applyRequest(( ) -> drive.withVelocityX(-m_driverPad.getLeftY( ) * MaxSpeed) // Drive forward with
               // negative Y (forward)

--- a/Comp2024/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2024/src/main/java/frc/robot/RobotContainer.java
@@ -14,7 +14,6 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
-import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -39,8 +38,6 @@ public class RobotContainer
   // Joysticks
   private final CommandXboxController          m_driverPad     = new CommandXboxController(Constants.kDriverPadPort);
   private final CommandXboxController          m_operatorPad   = new CommandXboxController(Constants.kOperatorPadPort);
-
-  private Field2d                              m_field         = new Field2d( );
 
   private double                               MaxSpeed        = TunerConstants.kSpeedAt12VoltsMps; // kSpeedAt12VoltsMps desired top speed
   private double                               MaxAngularRate  = 1.5 * Math.PI; // 3/4 of a rotation per second max angular velocity
@@ -117,7 +114,6 @@ public class RobotContainer
     // ShuffleboardTab m_autoTab = Shuffleboard.getTab("Auto");
     // ComplexWidget autoStopEntry = m_autoTab.add("AutoStop", new AutoStop(m_swerve)).withSize(3, 2).withPosition(0, 0);
     SmartDashboard.putData("AutoChooserRun", new InstantCommand(( ) -> runAutonomousCommand( )));
-    SmartDashboard.putData("Field", m_field);
   }
 
   /****************************************************************************

--- a/Comp2024/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2024/src/main/java/frc/robot/RobotContainer.java
@@ -21,7 +21,11 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.robot.commands.Dummy;
 import frc.robot.generated.TunerConstants;
+import frc.robot.subsystems.Climber;
 import frc.robot.subsystems.CommandSwerveDrivetrain;
+import frc.robot.subsystems.Feeder;
+import frc.robot.subsystems.Intake;
+import frc.robot.subsystems.Shooter;
 import frc.robot.subsystems.Telemetry;
 
 /**
@@ -56,6 +60,11 @@ public class RobotContainer
   // The robot's shared subsystems
 
   // These subsystems can use LED or vision and must be created afterward
+  public final CommandSwerveDrivetrain         drivetrain      = TunerConstants.DriveTrain; // My drivetrain
+  private final Intake                         m_intake        = new Intake( );
+  private final Shooter                        m_shooter       = new Shooter( );
+  private final Feeder                         m_feeder        = new Feeder( );
+  private final Climber                        m_climber       = new Climber( );
 
   // Chooser for autonomous commands
 
@@ -74,8 +83,6 @@ public class RobotContainer
   PathPlannerTrajectory                m_autoTrajectory;
 
   private SendableChooser<Integer>     m_odomChooser = new SendableChooser<>( );
-
-  public final CommandSwerveDrivetrain drivetrain    = TunerConstants.DriveTrain; // My drivetrain
 
   // Command Scheduler
 

--- a/Comp2024/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2024/src/main/java/frc/robot/RobotContainer.java
@@ -14,16 +14,12 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
-import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
-import edu.wpi.first.wpilibj2.command.button.JoystickButton;
-import edu.wpi.first.wpilibj2.command.button.POVButton;
-import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.commands.Dummy;
 import frc.robot.generated.TunerConstants;
 import frc.robot.subsystems.CommandSwerveDrivetrain;
@@ -38,10 +34,11 @@ import frc.robot.subsystems.Telemetry;
 public class RobotContainer
 {
   private static RobotContainer                m_instance;
+  private final boolean                        macOSXSim       = true;
 
   // Joysticks
-  private final XboxController                 m_driverPad     = new XboxController(Constants.kDriverPadPort);
-  private final XboxController                 m_operatorPad   = new XboxController(Constants.kOperatorPadPort);
+  private final CommandXboxController          m_driverPad     = new CommandXboxController(Constants.kDriverPadPort);
+  private final CommandXboxController          m_operatorPad   = new CommandXboxController(Constants.kOperatorPadPort);
 
   private Field2d                              m_field         = new Field2d( );
 
@@ -49,12 +46,9 @@ public class RobotContainer
   private double                               MaxAngularRate  = 1.5 * Math.PI; // 3/4 of a rotation per second max angular velocity
 
   /* Setting up bindings for necessary control of the swerve drive platform */
-  private final CommandXboxController          joystick        = new CommandXboxController(0); // My joystick
-
   private final SwerveRequest.FieldCentric     drive           =
       new SwerveRequest.FieldCentric( ).withDeadband(MaxSpeed * 0.1).withRotationalDeadband(MaxAngularRate * 0.1) // Add a 10% deadband
-          .withDriveRequestType(DriveRequestType.OpenLoopVoltage); // I want field-centric
-                                                                  // driving in open loop
+          .withDriveRequestType(DriveRequestType.OpenLoopVoltage); // I want field-centric driving in open loop
   private final SwerveRequest.SwerveDriveBrake brake           = new SwerveRequest.SwerveDriveBrake( );
   private final SwerveRequest.RobotCentric     forwardStraight =
       new SwerveRequest.RobotCentric( ).withDriveRequestType(DriveRequestType.OpenLoopVoltage);
@@ -97,8 +91,6 @@ public class RobotContainer
 
     configureButtonBindings( );
 
-    configureBindings( );
-
     initDefaultCommands( );
 
     initAutonomousChooser( );
@@ -140,123 +132,70 @@ public class RobotContainer
     //
     // Driver Controller Assignments
     //
-    final JoystickButton driverA = new JoystickButton(m_driverPad, XboxController.Button.kA.value);
-    final JoystickButton driverB = new JoystickButton(m_driverPad, XboxController.Button.kB.value);
-    final JoystickButton driverX = new JoystickButton(m_driverPad, XboxController.Button.kX.value);
-    final JoystickButton driverY = new JoystickButton(m_driverPad, XboxController.Button.kY.value);
-    //
-    final JoystickButton driverLeftBumper = new JoystickButton(m_driverPad, XboxController.Button.kLeftBumper.value);
-    final JoystickButton driverRightBumper = new JoystickButton(m_driverPad, XboxController.Button.kRightBumper.value);
-    final JoystickButton driverBack = new JoystickButton(m_driverPad, XboxController.Button.kBack.value); // aka View
-    final JoystickButton driverStart = new JoystickButton(m_driverPad, XboxController.Button.kStart.value); // aka Menu
-    //
-    final POVButton driverUp = new POVButton(m_driverPad, 0);
-    final POVButton driverRight = new POVButton(m_driverPad, 90);
-    final POVButton driverDown = new POVButton(m_driverPad, 180);
-    final POVButton driverLeft = new POVButton(m_driverPad, 270);
-    //
-    // Xbox enums { leftX = 0, leftY = 1, leftTrigger = 2, rightTrigger = 3, rightX = 4, rightY = 5}
-    final Trigger driverLeftTrigger = new Trigger(( ) -> m_driverPad.getLeftTriggerAxis( ) > Constants.kTriggerThreshold);
-    final Trigger driverRightTrigger = new Trigger(( ) -> m_driverPad.getRightTriggerAxis( ) > Constants.kTriggerThreshold);
-    // Xbox on MacOS { leftX = 0, leftY = 1, rightX = 2, rightY = 3, leftTrigger = 5, rightTrigger = 4}
-    // final Trigger driverLeftTrigger = new Trigger(( )->m_driverPad.getRightX() > Constants.kTriggerThreshold);
-    // final Trigger driverRightTrigger = new Trigger(( )->m_driverPad.getRightY() > Constants.kTriggerThreshold);
-
     // Driver - A, B, X, Y
-    driverA.onTrue(new Dummy("driver A"));
-    driverB.whileTrue(new Dummy("driver B"));
-    driverX.whileTrue(new Dummy("driver X"));
-    driverY.whileTrue(new Dummy("driver Y"));
+    // m_driverPad.a( ).onTrue(new Dummy("driver A"));                      // TODO: temporarily used for CTRE testing
+    // m_driverPad.b( ).whileTrue(new Dummy("driver B"));                   // TODO: temporarily used for CTRE testing
+    m_driverPad.x( ).whileTrue(new Dummy("driver X"));
+    m_driverPad.y( ).whileTrue(new Dummy("driver Y"));
     //
     // Driver - Bumpers, start, back
-    driverLeftBumper.onTrue(new Dummy("driver left bumper"));
-    driverRightBumper.onTrue(new Dummy("driver right bumper"));
-    driverBack.onTrue(new Dummy("driver back")); // aka View
-    driverStart.onTrue(new Dummy("driver start")); // aka Menu
+    // m_driverPad.leftBumper( ).onTrue(new Dummy("driver left bumper"));   // TODO: temporarily used for CTRE testing
+    m_driverPad.rightBumper( ).onTrue(new Dummy("driver right bumper"));
+    m_driverPad.back( ).onTrue(new Dummy("driver back")); // aka View
+    m_driverPad.start( ).onTrue(new Dummy("driver start")); // aka Menu
     //
     // Driver - POV buttons
-    driverUp.onTrue(new Dummy("driver 0"));
-    driverRight.onTrue(new Dummy("driver 90"));
-    driverDown.onTrue(new Dummy("driver 180"));
-    driverLeft.onTrue(new Dummy("driver 270"));
+    // m_driverPad.pov(0).onTrue(new Dummy("driver 0"));                    // TODO: temporarily used for CTRE testing
+    m_driverPad.pov(90).onTrue(new Dummy("driver 90"));
+    // m_driverPad.pov(180).onTrue(new Dummy("driver 180"));                // TODO: temporarily used for CTRE testing
+    m_driverPad.pov(270).onTrue(new Dummy("driver 270"));
     //
     // Driver Left/Right Trigger
-    driverLeftTrigger.onTrue(new Dummy("driver left trigger"));
-    driverRightTrigger.onTrue(new Dummy("driver right trigger"));
+    // Xbox enums { leftX = 0, leftY = 1, leftTrigger = 2, rightTrigger = 3, rightX = 4, rightY = 5}
+    // Xbox on MacOS { leftX = 0, leftY = 1, rightX = 2, rightY = 3, leftTrigger = 5, rightTrigger = 4}
+    m_driverPad.leftTrigger(Constants.kTriggerThreshold).onTrue(new Dummy("driver left trigger"));
+    m_driverPad.rightTrigger(Constants.kTriggerThreshold).onTrue(new Dummy("driver right trigger"));
 
     ///////////////////////////////////////////////////////
     //
     // Operator Controller Assignments
     //
-    final JoystickButton operA = new JoystickButton(m_operatorPad, XboxController.Button.kA.value);
-    final JoystickButton operB = new JoystickButton(m_operatorPad, XboxController.Button.kB.value);
-    final JoystickButton operX = new JoystickButton(m_operatorPad, XboxController.Button.kX.value);
-    final JoystickButton operY = new JoystickButton(m_operatorPad, XboxController.Button.kY.value);
-    //
-    final JoystickButton operLeftBumper = new JoystickButton(m_operatorPad, XboxController.Button.kLeftBumper.value);
-    final JoystickButton operRightBumper = new JoystickButton(m_operatorPad, XboxController.Button.kRightBumper.value);
-    final JoystickButton operBack = new JoystickButton(m_operatorPad, XboxController.Button.kBack.value); // aka View
-    final JoystickButton operStart = new JoystickButton(m_operatorPad, XboxController.Button.kStart.value); // aka Menu
-    //
-    final POVButton operUp = new POVButton(m_operatorPad, 0);
-    final POVButton operRight = new POVButton(m_operatorPad, 90);
-    final POVButton operDown = new POVButton(m_operatorPad, 180);
-    final POVButton operLeft = new POVButton(m_operatorPad, 270);
-    // 
-    // Xbox enums { leftX = 0, leftY = 1, leftTrigger = 2, rightTrigger = 3, rightX = 4, rightY = 5}
-    final Trigger operLeftTrigger = new Trigger(( ) -> m_operatorPad.getLeftTriggerAxis( ) > Constants.kTriggerThreshold);
-    final Trigger operRightTrigger = new Trigger(( ) -> m_operatorPad.getRightTriggerAxis( ) > Constants.kTriggerThreshold);
-    // Xbox on MacOS { leftX = 0, leftY = 1, rightX = 2, rightY = 3, leftTrigger = 5, rightTrigger = 4}
-    // final Trigger operLeftTrigger = new Trigger(( ) -> m_operatorPad.getRightX( ) > Constants.kTriggerThreshold);
-    // final Trigger operRightTrigger = new Trigger(( ) -> m_operatorPad.getRightY( ) > Constants.kTriggerThreshold);
-
     // Operator - A, B, X, Y
-    operA.onTrue(new Dummy("oper A"));
-    operB.whileTrue(new Dummy("oper B"));
-    operX.whileTrue(new Dummy("oper X"));
-    operY.whileTrue(new Dummy("oper Y"));
+    m_operatorPad.a( ).onTrue(new Dummy("oper A"));
+    m_operatorPad.b( ).whileTrue(new Dummy("oper B"));
+    m_operatorPad.x( ).whileTrue(new Dummy("oper X"));
+    m_operatorPad.y( ).whileTrue(new Dummy("oper Y"));
     //
     // Operator - Bumpers, start, back
-    operLeftBumper.onTrue(new Dummy("oper left bumper"));
-    operRightBumper.onTrue(new Dummy("oper right bumper"));
-    operBack.onTrue(new Dummy("oper back")); // aka View
-    operStart.onTrue(new Dummy("oper start")); // aka Menu
+    m_operatorPad.leftBumper( ).onTrue(new Dummy("oper left bumper"));
+    m_operatorPad.rightBumper( ).onTrue(new Dummy("oper right bumper"));
+    m_operatorPad.back( ).onTrue(new Dummy("oper back")); // aka View
+    m_operatorPad.start( ).onTrue(new Dummy("oper start")); // aka Menu
     //
     // Operator - POV buttons
-    operUp.onTrue(new Dummy("oper 0"));
-    operRight.onTrue(new Dummy("oper 90"));
-    operDown.onTrue(new Dummy("oper 180"));
-    operLeft.onTrue(new Dummy("oper 270"));
+    m_operatorPad.pov(0).onTrue(new Dummy("oper 0"));
+    m_operatorPad.pov(90).onTrue(new Dummy("oper 90"));
+    m_operatorPad.pov(180).onTrue(new Dummy("oper 180"));
+    m_operatorPad.pov(270).onTrue(new Dummy("oper 270"));
     //
     // Operator Left/Right Trigger
-    operLeftTrigger.onTrue(new Dummy("oper left trigger"));
-    operRightTrigger.onTrue(new Dummy("oper right trigger"));
-  }
+    // Xbox enums { leftX = 0, leftY = 1, leftTrigger = 2, rightTrigger = 3, rightX = 4, rightY = 5}
+    // Xbox on MacOS { leftX = 0, leftY = 1, rightX = 2, rightY = 3, leftTrigger = 5, rightTrigger = 4}
+    m_operatorPad.leftTrigger(Constants.kTriggerThreshold).onTrue(new Dummy("oper left trigger"));
+    m_operatorPad.rightTrigger(Constants.kTriggerThreshold).onTrue(new Dummy("oper right trigger"));
 
-  // Taken from CTRE-SwerveWithPathPlanner
-  private void configureBindings( )
-  {
-    drivetrain.setDefaultCommand( // Drivetrain will execute this command periodically
-        drivetrain.applyRequest(( ) -> drive.withVelocityX(-joystick.getLeftY( ) * MaxSpeed) // Drive forward with
-            // negative Y (forward)
-            .withVelocityY(-joystick.getLeftX( ) * MaxSpeed) // Drive left with negative X (left)
-            .withRotationalRate(-joystick.getRightX( ) * MaxAngularRate) // Drive counterclockwise with negative X (left)
-        ).ignoringDisable(true));
-
-    joystick.a( ).whileTrue(drivetrain.applyRequest(( ) -> brake));
-    joystick.b( ).whileTrue(
-        drivetrain.applyRequest(( ) -> point.withModuleDirection(new Rotation2d(-joystick.getLeftY( ), -joystick.getLeftX( )))));
+    ///////////////////////////////////////////////////////
+    //
+    // From CTRE SwerveWithPathPlanner template - mainly for testing
+    m_driverPad.a( ).whileTrue(drivetrain.applyRequest(( ) -> brake));
+    m_driverPad.b( ).whileTrue(drivetrain
+        .applyRequest(( ) -> point.withModuleDirection(new Rotation2d(-m_driverPad.getLeftY( ), -m_driverPad.getLeftX( )))));
 
     // reset the field-centric heading on left bumper press
-    joystick.leftBumper( ).onTrue(drivetrain.runOnce(( ) -> drivetrain.seedFieldRelative( )));
+    m_driverPad.leftBumper( ).onTrue(drivetrain.runOnce(( ) -> drivetrain.seedFieldRelative( )));
 
-    // if (Utils.isSimulation()) {
-    //   drivetrain.seedFieldRelative(new Pose2d(new Translation2d(), Rotation2d.fromDegrees(90)));
-    // }
-    drivetrain.registerTelemetry(logger::telemeterize);
-
-    joystick.pov(0).whileTrue(drivetrain.applyRequest(( ) -> forwardStraight.withVelocityX(0.5).withVelocityY(0)));
-    joystick.pov(180).whileTrue(drivetrain.applyRequest(( ) -> forwardStraight.withVelocityX(-0.5).withVelocityY(0)));
+    m_driverPad.pov(0).whileTrue(drivetrain.applyRequest(( ) -> forwardStraight.withVelocityX(0.5).withVelocityY(0)));
+    m_driverPad.pov(180).whileTrue(drivetrain.applyRequest(( ) -> forwardStraight.withVelocityX(-0.5).withVelocityY(0)));
   }
 
   /****************************************************************************
@@ -265,7 +204,27 @@ public class RobotContainer
    */
   private void initDefaultCommands( )
   {
-    // m_swerve.setDefaultCommand(new DriveTeleop(m_swerve, m_driverPad));
+    if (!macOSXSim)
+      drivetrain.setDefaultCommand( // Drivetrain will execute this command periodically
+          drivetrain.applyRequest(( ) -> drive.withVelocityX(-m_driverPad.getLeftY( ) * MaxSpeed) // Drive forward with
+              // negative Y (forward)
+              .withVelocityY(-m_driverPad.getLeftX( ) * MaxSpeed) // Drive left with negative X (left)
+              .withRotationalRate(-m_driverPad.getRightX( ) * MaxAngularRate) // Drive counterclockwise with negative X (left)
+          ).ignoringDisable(true));
+
+    else
+      drivetrain.setDefaultCommand( // Drivetrain will execute this command periodically
+          drivetrain.applyRequest(( ) -> drive.withVelocityX(-m_driverPad.getLeftY( ) * MaxSpeed) // Drive forward with
+              // negative Y (forward)
+              .withVelocityY(-m_driverPad.getLeftX( ) * MaxSpeed) // Drive left with negative X (left)
+              .withRotationalRate(-m_driverPad.getLeftTriggerAxis( ) * MaxAngularRate) // Drive counterclockwise with negative X (left)
+          ).ignoringDisable(true));
+
+    // if (Utils.isSimulation()) {
+    //   drivetrain.seedFieldRelative(new Pose2d(new Translation2d(), Rotation2d.fromDegrees(90)));
+    // }
+
+    drivetrain.registerTelemetry(logger::telemeterize);
 
     // // Default command - Motion Magic hold
     // m_elbow.setDefaultCommand(new ElbowMoveToPosition(m_elbow));
@@ -393,12 +352,12 @@ public class RobotContainer
     return m_odomChooser.getSelected( );
   }
 
-  public XboxController getDriver( )
+  public CommandXboxController getDriver( )
   {
     return m_driverPad;
   }
 
-  public XboxController getOperator( )
+  public CommandXboxController getOperator( )
   {
     return m_operatorPad;
   }

--- a/Comp2024/src/main/java/frc/robot/lib/util/PhoenixUtil6.java
+++ b/Comp2024/src/main/java/frc/robot/lib/util/PhoenixUtil6.java
@@ -2,7 +2,6 @@ package frc.robot.lib.util;
 
 import com.ctre.phoenix6.StatusCode;
 import com.ctre.phoenix6.StatusSignal;
-import com.ctre.phoenix6.Utils;
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.configs.Pigeon2Configuration;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;

--- a/Comp2024/src/main/java/frc/robot/subsystems/Climber.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Climber.java
@@ -6,6 +6,7 @@ package frc.robot.subsystems;
 import com.ctre.phoenix6.hardware.TalonFX;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.Ports;
 
 //
 // Climber subsystem class
@@ -13,8 +14,8 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 public class Climber extends SubsystemBase
 {
   // Member objects
-  private final TalonFX m_climberL = new TalonFX(0);
-  private final TalonFX m_climberR = new TalonFX(0);
+  private final TalonFX m_climberL = new TalonFX(Ports.kCANID_ClimberL);
+  private final TalonFX m_climberR = new TalonFX(Ports.kCANID_ClimberR);
 
   //Devices and simulation objs
 

--- a/Comp2024/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -61,13 +61,14 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
       driveBaseRadius = Math.max(driveBaseRadius, moduleLocation.getNorm( ));
     }
 
-    AutoBuilder.configureHolonomic(( ) -> this.getState( ).Pose, // Supplier of current robot pose
-        this::seedFieldRelative,  // Consumer for seeding pose against auto
-        this::getCurrentRobotChassisSpeeds, (speeds) -> this.setControl(autoRequest.withSpeeds(speeds)), // Consumer of ChassisSpeeds to drive the robot
+    AutoBuilder.configureHolonomic(( ) -> this.getState( ).Pose,      // Supplier of current robot pose
+        this::seedFieldRelative,                                      // Consumer for seeding pose against auto
+        this::getCurrentRobotChassisSpeeds,                           // Supplier of chassis speeds
+        (speeds) -> this.setControl(autoRequest.withSpeeds(speeds)),  // Consumer of ChassisSpeeds to drive the robot
         new HolonomicPathFollowerConfig(new PIDConstants(10, 0, 0), new PIDConstants(10, 0, 0), TunerConstants.kSpeedAt12VoltsMps,
-            driveBaseRadius, new ReplanningConfig( )),
-        ( ) -> false, // Change this if the path needs to be flipped on red vs blue
-        this); // Subsystem for requirements
+            driveBaseRadius, new ReplanningConfig( )),                // Path following config
+        ( ) -> false,                                                 // Change this if the path needs to be flipped on red vs blue
+        this);                                                        // Subsystem for requirements
   }
 
   public Command applyRequest(Supplier<SwerveRequest> requestSupplier)

--- a/Comp2024/src/main/java/frc/robot/subsystems/Feeder.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Feeder.java
@@ -9,6 +9,7 @@ import com.ctre.phoenix6.hardware.TalonFX;
 
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.Ports;
 
 //
 // Feeder subsystem class
@@ -16,10 +17,10 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 public class Feeder extends SubsystemBase
 {
   // Member objects
-  private final WPI_TalonSRX m_feederRoller = new WPI_TalonSRX(0);
-  private final TalonFX      m_feederRotor  = new TalonFX(0);
-  private final CANcoder     m_CANCoder     = new CANcoder(0);
-  private final DigitalInput m_limitSwitch  = new DigitalInput(0);
+  private final WPI_TalonSRX m_feederRoller = new WPI_TalonSRX(Ports.kCANID_FeederRoller);
+  private final TalonFX      m_feederRotary = new TalonFX(Ports.kCANID_FeederRotary);
+  private final CANcoder     m_CANCoder     = new CANcoder(Ports.kCANID_FeederCANCoder);
+  private final DigitalInput m_noteInFeeder = new DigitalInput(Ports.kDIO1_NoteInFeeder);
 
   //Devices and simulation objs
 

--- a/Comp2024/src/main/java/frc/robot/subsystems/Intake.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Intake.java
@@ -9,6 +9,7 @@ import com.ctre.phoenix6.hardware.TalonFX;
 
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.Ports;
 
 //
 // Intake subsystem class
@@ -16,10 +17,10 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 public class Intake extends SubsystemBase
 {
   // Member objects
-  private final WPI_TalonSRX m_intakeRoller = new WPI_TalonSRX(0);
-  private final TalonFX      m_intakeRotor  = new TalonFX(0);
-  private final CANcoder     m_CANCoder     = new CANcoder(0);
-  private final DigitalInput m_limitSwitch  = new DigitalInput(0);
+  private final WPI_TalonSRX m_intakeRoller = new WPI_TalonSRX(Ports.kCANID_IntakeRoller);
+  private final TalonFX      m_intakeRotor  = new TalonFX(Ports.kCANID_IntakeRotary);
+  private final CANcoder     m_CANCoder     = new CANcoder(Ports.kCANID_IntakeCANCoder);
+  private final DigitalInput m_notInIntake  = new DigitalInput(Ports.kDIO0_NoteInIntake);
 
   //Devices and simulation objs
 

--- a/Comp2024/src/main/java/frc/robot/subsystems/Intake.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Intake.java
@@ -18,7 +18,7 @@ public class Intake extends SubsystemBase
 {
   // Member objects
   private final WPI_TalonSRX m_intakeRoller = new WPI_TalonSRX(Ports.kCANID_IntakeRoller);
-  private final TalonFX      m_intakeRotor  = new TalonFX(Ports.kCANID_IntakeRotary);
+  private final TalonFX      m_intakeRotary = new TalonFX(Ports.kCANID_IntakeRotary);
   private final CANcoder     m_CANCoder     = new CANcoder(Ports.kCANID_IntakeCANCoder);
   private final DigitalInput m_notInIntake  = new DigitalInput(Ports.kDIO0_NoteInIntake);
 

--- a/Comp2024/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Shooter.java
@@ -6,6 +6,7 @@ package frc.robot.subsystems;
 import com.ctre.phoenix6.hardware.TalonFX;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.Ports;
 
 //
 // Shooter subsystem class
@@ -13,7 +14,8 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 public class Shooter extends SubsystemBase
 {
   // Member objects
-  private final TalonFX m_shooter = new TalonFX(0);
+  private final TalonFX m_shooterL = new TalonFX(Ports.kCANID_ShooterL);
+  private final TalonFX m_shooterR = new TalonFX(Ports.kCANID_ShooterR);
 
   //Devices and simulation objs
 

--- a/Comp2024/src/main/java/frc/robot/subsystems/Telemetry.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Telemetry.java
@@ -16,7 +16,6 @@ import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj.util.Color8Bit;
-import frc.robot.lib.util.PhoenixUtil6;
 
 public class Telemetry
 {

--- a/Comp2024/vendordeps/PathplannerLib.json
+++ b/Comp2024/vendordeps/PathplannerLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PathplannerLib.json",
     "name": "PathplannerLib",
-    "version": "2024.1.2",
+    "version": "2024.1.6",
     "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
     "frcYear": "2024",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-java",
-            "version": "2024.1.2"
+            "version": "2024.1.6"
         }
     ],
     "jniDependencies": [],
@@ -20,7 +20,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-cpp",
-            "version": "2024.1.2",
+            "version": "2024.1.6",
             "libName": "PathplannerLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
The CTRE swerve with PathPlanner example uses CommandXBoxController. CommandXBoxController is a wrapper class that includes the base XBoxController that we used before AND adds the ability to bind commands to buttons directly. This commit updates all of our Comp2024 buttons (currently assigned to the Dummy() command for now) to use the new CommandXBoxController class.

This also tests using an XBox controller on a MacBook in simulation mode to correctly drive around the new Pose widget. There are a few test buttons left assigned for resetting the odometry and basic driving.