### PR TITLE
Update motor and cancoder valid checks

### DIFF
--- a/Comp2024/src/main/java/frc/robot/lib/util/PhoenixUtil6.java
+++ b/Comp2024/src/main/java/frc/robot/lib/util/PhoenixUtil6.java
@@ -72,7 +72,7 @@ public class PhoenixUtil6
         DataLogManager.log(String.format("%s: ID %2d - %s motor: getConfigurator.apply - %s!", m_className, deviceID, name,
             status.getDescription( )));
 
-    if ((status = motor.setControl(new VoltageOut(0).withEnableFOC(false))) != StatusCode.OK)
+    if ((status = motor.setControl(new VoltageOut(0))) != StatusCode.OK)
       DataLogManager
           .log(String.format("%s: ID %2d - %s motor: setControl - %s!", m_className, deviceID, name, status.getDescription( )));
 

--- a/Comp2024/src/main/java/frc/robot/subsystems/Climber.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Climber.java
@@ -79,7 +79,7 @@ public class Climber extends SubsystemBase
   // Declare module variables
   private static boolean            m_isComp;
 
-  private boolean                   m_motorValid;                   // Health indicator for Falcon 
+  private boolean                   m_climberValid;               // Health indicator for Falcon 
   private boolean                   m_calibrated         = true;
   private boolean                   m_debug              = true;
   private double                    m_currentInches      = 0.0;    // Current length in inches
@@ -111,7 +111,7 @@ public class Climber extends SubsystemBase
     setSubsystem("Climber");
     m_isComp = isComp;
 
-    m_motorValid = PhoenixUtil6.getInstance( ).talonFXInitialize6(m_climberL, "ClimberL", CTREConfigs6.climberLengthFXConfig( ))
+    m_climberValid = PhoenixUtil6.getInstance( ).talonFXInitialize6(m_climberL, "ClimberL", CTREConfigs6.climberLengthFXConfig( ))
         && PhoenixUtil6.getInstance( ).talonFXInitialize6(m_climberR, "ClimberR", CTREConfigs6.climberLengthFXConfig( ));
     m_climberR.setControl(new Follower(m_climberL.getDeviceID( ), false));
 
@@ -183,7 +183,8 @@ public class Climber extends SubsystemBase
   private void initSmartDashboard( )
   {
     // Initialize dashboard widgets
-    SmartDashboard.putBoolean("HL_validCL", m_motorValid);
+    SmartDashboard.putBoolean("HL_CLValid", m_climberValid);
+
     SmartDashboard.putNumber("CL_ArbFF", 0.0);
     SmartDashboard.putData("ClimberMech", m_climberMech);
   }
@@ -227,7 +228,7 @@ public class Climber extends SubsystemBase
 
   public void resetPositionToZero( )
   {
-    if (m_motorValid)
+    if (m_climberValid)
       m_climberL.setPosition(Conversions.inchesToWinchRotations(0, kRolloutRatio));
   }
 
@@ -348,7 +349,7 @@ public class Climber extends SubsystemBase
 
   public void moveToCalibrate( )
   {
-    if (m_motorValid)
+    if (m_climberValid)
       m_climberL.setControl(m_requestVolts.withOutput(kCalibrateSpeedVolts));
   }
 

--- a/Comp2024/src/main/java/frc/robot/subsystems/Climber.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Climber.java
@@ -87,11 +87,11 @@ public class Climber extends SubsystemBase
   private int                       m_hardStopCounter    = 0;
 
   // Manual mode config parameters
-  private VoltageOut                m_requestVolts       = new VoltageOut(0).withEnableFOC(false);
+  private VoltageOut                m_requestVolts       = new VoltageOut(0);
   private ClimberMode               m_mode               = ClimberMode.INIT;  // Manual movement mode with joysticks
 
   // Motion Magic config parameters
-  private MotionMagicVoltage        m_requestMMVolts     = new MotionMagicVoltage(0).withSlot(0).withEnableFOC(false);
+  private MotionMagicVoltage        m_requestMMVolts     = new MotionMagicVoltage(0).withSlot(0);
   private Debouncer                 m_withinTolerance    = new Debouncer(0.060, DebounceType.kRising);
   private Timer                     m_safetyTimer        = new Timer( ); // Safety timer for movements
   private double                    m_totalArbFeedForward;   // Arbitrary feedforward added to counteract gravity

--- a/Comp2024/src/main/java/frc/robot/subsystems/Intake.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Intake.java
@@ -101,11 +101,11 @@ public class Intake extends SubsystemBase
   private double                    m_targetDegrees       = 0.0; // Target angle in degrees
 
   // Manual mode config parameters
-  private VoltageOut                m_requestVolts        = new VoltageOut(0).withEnableFOC(false);
+  private VoltageOut                m_requestVolts        = new VoltageOut(0);
   private RotaryMode                m_rotaryMode          = RotaryMode.INIT;     // Manual movement mode with joysticks
 
   // Motion Magic config parameters
-  private MotionMagicVoltage        m_requestMMVolts      = new MotionMagicVoltage(0).withSlot(0).withEnableFOC(false);
+  private MotionMagicVoltage        m_requestMMVolts      = new MotionMagicVoltage(0).withSlot(0);
   private Debouncer                 m_withinTolerance     = new Debouncer(0.060, DebounceType.kRising);
   private Timer                     m_safetyTimer         = new Timer( ); // Safety timer for movements
   private boolean                   m_moveIsFinished;  // Movement has completed (within tolerance)

--- a/Comp2024/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Shooter.java
@@ -49,7 +49,7 @@ public class Shooter extends SubsystemBase
   // Declare module variables
   private static boolean        m_isComp;
 
-  private boolean               m_valid                 = false; // Health indicator for shooter talon 11
+  private boolean               m_shooterValid;
   private boolean               m_atDesiredSpeed        = false; // Indicates flywheel RPM is close to target
   private boolean               m_atDesiredSpeedPrevious;
 
@@ -64,12 +64,11 @@ public class Shooter extends SubsystemBase
     setSubsystem("Shooter");
     m_isComp = isComp;
 
-    m_valid = PhoenixUtil6.getInstance( ).talonFXInitialize6(m_shooterLower, "Lower", CTREConfigs6.shooterFXConfig( ))
+    m_shooterValid = PhoenixUtil6.getInstance( ).talonFXInitialize6(m_shooterLower, "Lower", CTREConfigs6.shooterFXConfig( ))
         && PhoenixUtil6.getInstance( ).talonFXInitialize6(m_shooterUpper, "Upper", CTREConfigs6.shooterFXConfig( ));
     m_shooterUpper.setControl(new Follower(m_shooterLower.getDeviceID( ), true));
 
-    SmartDashboard.putNumber("SH_targetRPM", kFlywheelLowerTargetRPM);
-
+    initSmartDashboard( );
     initialize( );
   }
 
@@ -81,7 +80,7 @@ public class Shooter extends SubsystemBase
     double current = 0.0;
 
     // Calculate flywheel RPM and display on dashboard
-    if (m_valid)
+    if (m_shooterValid)
     {
       m_flywheelRPM = m_flywheelFilter.calculate((m_shooterLower.getVelocity( ).refresh( ).getValue( ) * 60.0));
 
@@ -127,6 +126,13 @@ public class Shooter extends SubsystemBase
 
   // Put methods for controlling this subsystem here. Call these from Commands.
 
+  private void initSmartDashboard( )
+  {
+    SmartDashboard.putBoolean("HL_SHValid", m_shooterValid);
+
+    SmartDashboard.putNumber("SH_targetRPM", kFlywheelLowerTargetRPM);
+  }
+
   public void initialize( )
   {
     DataLogManager.log(getSubsystem( ) + ": subsystem initialized!");
@@ -158,7 +164,7 @@ public class Shooter extends SubsystemBase
         break;
     }
 
-    if (m_valid)
+    if (m_shooterValid)
       m_shooterLower.setControl(
           m_requestVelocity.withVelocity(Conversions.rotationsToInputRotations(m_flywheelRPM / 60.0, kFlywheelGearRatio)));
     DataLogManager.log(getSubsystem( ) + ": target speed is " + m_flywheelRPM);

--- a/Comp2024/vendordeps/PathplannerLib.json
+++ b/Comp2024/vendordeps/PathplannerLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PathplannerLib.json",
     "name": "PathplannerLib",
-    "version": "2024.1.6",
+    "version": "2024.2.3",
     "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
     "frcYear": "2024",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-java",
-            "version": "2024.1.6"
+            "version": "2024.2.3"
         }
     ],
     "jniDependencies": [],
@@ -20,7 +20,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-cpp",
-            "version": "2024.1.6",
+            "version": "2024.2.3",
             "libName": "PathplannerLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,

--- a/Comp2024/vendordeps/Phoenix6.json
+++ b/Comp2024/vendordeps/Phoenix6.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix6.json",
     "name": "CTRE-Phoenix (v6)",
-    "version": "24.1.0",
+    "version": "24.2.0",
     "frcYear": 2024,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -19,14 +19,14 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-java",
-            "version": "24.1.0"
+            "version": "24.2.0"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -39,7 +39,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -52,7 +52,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -65,7 +65,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -78,7 +78,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -91,7 +91,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -104,7 +104,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -117,7 +117,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -130,7 +130,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -143,7 +143,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -158,7 +158,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-cpp",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_Phoenix6_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -173,7 +173,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -188,7 +188,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_Phoenix6_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -203,7 +203,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -218,7 +218,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -233,7 +233,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -248,7 +248,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -263,7 +263,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -278,7 +278,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -293,7 +293,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -308,7 +308,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -323,7 +323,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "24.1.0",
+            "version": "24.2.0",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,


### PR DESCRIPTION
Added validity checks to reduce error message logging when CTRE devices aren't present on the CAN bus. This happens when working with partially assembled robots.