### PR TITLE
Bugfixes and tuning for NASA practice using practice robot

### DIFF
--- a/Comp2024/src/main/java/frc/robot/Constants.java
+++ b/Comp2024/src/main/java/frc/robot/Constants.java
@@ -175,11 +175,11 @@ public class Constants
     }
 
     // Rotary angles - Motion Magic move parameters
-    public static final double kRotaryAngleRetracted = -80.0;    // TODO: Tune me!
+    public static final double kRotaryAngleRetracted = -85.0;    // TODO: Tune me!
     public static final double kRotaryAngleHandoff   = 0.0;      // TODO: Tune me!
-    public static final double kRotaryAngleDeployed  = 110.0;    // TODO: Tune me!
+    public static final double kRotaryAngleDeployed  = 115.0;    // TODO: Tune me!
     public static final double kRotaryAngleMin       = -88.0;    // TODO: Tune me!
-    public static final double kRotaryAngleMax       = 115.0;    // TODO: Tune me!
+    public static final double kRotaryAngleMax       = 125.0;    // TODO: Tune me!
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/Comp2024/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2024/src/main/java/frc/robot/RobotContainer.java
@@ -290,7 +290,7 @@ public class RobotContainer
 
     // Default command - manual mode
     // m_intake.setDefaultCommand(new IntakeRotaryJoysticks(m_intake, m_operatorPad.getHID( )));
-    // m_climber.setDefaultCommand(new ClimberRun(m_climber));
+    m_climber.setDefaultCommand(new ClimberMoveWithJoystick(m_climber, m_operatorPad.getHID( )));
     // m_feeder.setDefaultCommand(new FeederRun(m_feeder));
   }
 

--- a/Comp2024/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2024/src/main/java/frc/robot/RobotContainer.java
@@ -8,13 +8,13 @@ package frc.robot;
 
 import com.ctre.phoenix6.mechanisms.swerve.SwerveModule.DriveRequestType;
 import com.ctre.phoenix6.mechanisms.swerve.SwerveRequest;
+import com.pathplanner.lib.commands.PathPlannerAuto;
 import com.pathplanner.lib.path.PathPlannerPath;
 import com.pathplanner.lib.path.PathPlannerTrajectory;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
@@ -24,7 +24,6 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
-import frc.robot.Constants;
 import frc.robot.Constants.CLConsts;
 import frc.robot.Constants.INConsts;
 import frc.robot.Constants.INConsts.RollerMode;
@@ -43,6 +42,7 @@ import frc.robot.commands.IntakeActionShoot;
 import frc.robot.commands.IntakeMoveWithJoystick;
 import frc.robot.commands.IntakeRun;
 import frc.robot.commands.LEDSet;
+import frc.robot.commands.ShooterActionFire;
 import frc.robot.commands.ShooterRun;
 import frc.robot.generated.TunerConstants;
 import frc.robot.subsystems.Climber;
@@ -79,6 +79,7 @@ public class RobotContainer
           .withDriveRequestType(DriveRequestType.OpenLoopVoltage); // We want field-centric driving in open loop
   private final SwerveRequest.SwerveDriveBrake        brake          = new SwerveRequest.SwerveDriveBrake( );
   private final SwerveRequest.FieldCentricFacingAngle facing         = new SwerveRequest.FieldCentricFacingAngle( );
+  private final SwerveRequest.PointWheelsAt           point          = new SwerveRequest.PointWheelsAt( );
 
   private final Telemetry                             logger         = new Telemetry(MaxSpeed);
 
@@ -203,24 +204,20 @@ public class RobotContainer
     m_driverPad.leftBumper( ).onTrue(new Dummy("driver left bumper"));  // Drive to pose: amp
     m_driverPad.rightBumper( ).onTrue(new IntakeActionAcquire(m_intake));
     m_driverPad.rightBumper( ).onFalse(new IntakeActionRetract(m_intake));
-    m_driverPad.back( ).whileTrue(m_drivetrain.applyRequest(( ) -> brake));                          // aka View
+    m_driverPad.back( ).whileTrue(m_drivetrain.applyRequest(( ) -> brake));                       // aka View
     m_driverPad.start( ).onTrue(m_drivetrain.runOnce(( ) -> m_drivetrain.seedFieldRelative( )));  // aka Menu
     //
     // Driver - POV buttons
-    m_driverPad.pov(0)
-        .whileTrue(m_drivetrain.applyRequest(( ) -> facing.withTargetDirection(new Rotation2d(Units.degreesToRadians(0.0)))));
-    m_driverPad.pov(90)
-        .whileTrue(m_drivetrain.applyRequest(( ) -> facing.withTargetDirection(new Rotation2d(Units.degreesToRadians(270.0)))));
-    m_driverPad.pov(180)
-        .whileTrue(m_drivetrain.applyRequest(( ) -> facing.withTargetDirection(new Rotation2d(Units.degreesToRadians(180.0)))));
-    m_driverPad.pov(270)
-        .whileTrue(m_drivetrain.applyRequest(( ) -> facing.withTargetDirection(new Rotation2d(Units.degreesToRadians(90.0)))));
+    m_driverPad.pov(0).whileTrue(m_drivetrain.applyRequest(( ) -> point.withModuleDirection(Rotation2d.fromDegrees(0))));
+    m_driverPad.pov(90).whileTrue(m_drivetrain.applyRequest(( ) -> point.withModuleDirection(Rotation2d.fromDegrees(270))));
+    m_driverPad.pov(180).whileTrue(m_drivetrain.applyRequest(( ) -> point.withModuleDirection(Rotation2d.fromDegrees(180))));
+    m_driverPad.pov(270).whileTrue(m_drivetrain.applyRequest(( ) -> point.withModuleDirection(Rotation2d.fromDegrees(90))));
     //
     // Driver Left/Right Trigger
     // Xbox enums { leftX = 0, leftY = 1, leftTrigger = 2, rightTrigger = 3, rightX = 4, rightY = 5}
     // Xbox on MacOS { leftX = 0, leftY = 1, rightX = 2, rightY = 3, leftTrigger = 5, rightTrigger = 4}
     m_driverPad.leftTrigger(Constants.kTriggerThreshold).onTrue(new Dummy("driver left trigger"));  // Drive to pose: speaker
-    m_driverPad.rightTrigger(Constants.kTriggerThreshold).onTrue(new IntakeActionExpel(m_intake));
+    m_driverPad.rightTrigger(Constants.kTriggerThreshold).onTrue(new ShooterActionFire(m_shooter, m_intake));
 
     m_driverPad.rightStick( ).onTrue(new Dummy("driver right stick"));
     m_driverPad.leftStick( ).onTrue(new Dummy("driver left stick"));
@@ -233,14 +230,14 @@ public class RobotContainer
     m_operatorPad.a( ).onTrue(new ShooterRun(m_shooter, ShooterMode.SCORE));
     m_operatorPad.b( ).onTrue(new ShooterRun(m_shooter, ShooterMode.STOP));
     m_operatorPad.x( ).onTrue(new ShooterRun(m_shooter, ShooterMode.SCORE));
-    m_operatorPad.y( ).onTrue(new Dummy("oper Y"));
+    m_operatorPad.y( ).onTrue(new IntakeActionExpel(m_intake));
     //
     // Operator - Bumpers, start, back
     m_operatorPad.leftBumper( ).onTrue(new IntakeActionExpel(m_intake));
     m_operatorPad.rightBumper( ).onTrue(new IntakeActionAcquire(m_intake));
     m_operatorPad.rightBumper( ).onFalse(new IntakeActionRetract(m_intake));
-    m_operatorPad.back( ).toggleOnTrue(new ClimberMoveWithJoystick(m_climber, m_operatorPad.getHID( )));                          // aka View
-    m_operatorPad.start( ).onTrue(new Dummy("oper start"));  // aka Menu
+    m_operatorPad.back( ).toggleOnTrue(new ClimberMoveWithJoystick(m_climber, m_operatorPad.getHID( )));  // aka View
+    m_operatorPad.start( ).onTrue(new InstantCommand(m_vision::setCameraToSecondary));                    // aka Menu
     //
     // Operator - POV buttons
     m_operatorPad.pov(0).onTrue(new ClimberMoveToPosition(m_climber, CLConsts.kLengthFull));
@@ -251,8 +248,8 @@ public class RobotContainer
     // Operator Left/Right Trigger
     // Xbox enums { leftX = 0, leftY = 1, leftTrigger = 2, rightTrigger = 3, rightX = 4, rightY = 5}
     // Xbox on MacOS { leftX = 0, leftY = 1, rightX = 2, rightY = 3, leftTrigger = 5, rightTrigger = 4}
-    m_operatorPad.rightTrigger(Constants.kTriggerThreshold).onTrue(new IntakeActionShoot(m_intake));
     m_operatorPad.leftTrigger(Constants.kTriggerThreshold).onTrue(new Dummy("oper left trigger"));
+    m_operatorPad.rightTrigger(Constants.kTriggerThreshold).onTrue(new ShooterActionFire(m_shooter, m_intake));
 
     m_operatorPad.rightStick( ).toggleOnTrue(new IntakeMoveWithJoystick(m_intake, m_operatorPad.getHID( )));
     m_operatorPad.leftStick( ).onTrue(new Dummy("oper left stick"));
@@ -355,6 +352,7 @@ public class RobotContainer
       m_autoCommand = new AutoStop(m_drivetrain);
     else
     {
+      m_drivetrain.resetOdometry(PathPlannerAuto.getStaringPoseFromAutoFile(pathName));
       switch (mode)
       {
         default :

--- a/Comp2024/src/main/java/frc/robot/RobotContainer.java
+++ b/Comp2024/src/main/java/frc/robot/RobotContainer.java
@@ -70,12 +70,12 @@ public class RobotContainer
   private static final CommandXboxController          m_operatorPad  = new CommandXboxController(Constants.kOperatorPadPort);
 
   private double                                      MaxSpeed       = TunerConstants.kSpeedAt12VoltsMps; // kSpeedAt12VoltsMps desired top speed
-  private double                                      MaxAngularRate = 1.5 * Math.PI; // 3/4 of a rotation per second max angular velocity
+  private double                                      MaxAngularRate = 3.0 * Math.PI; // 3/4 of a rotation per second max angular velocity
   private Command                                     m_autoCommand;
 
   /* Setting up bindings for necessary control of the swerve drive platform */
   private final SwerveRequest.FieldCentric            drive          =
-      new SwerveRequest.FieldCentric( ).withDeadband(MaxSpeed * 0.1).withRotationalDeadband(MaxAngularRate * 0.1) // Add a 10% deadband
+      new SwerveRequest.FieldCentric( ).withDeadband(MaxSpeed * 0.15).withRotationalDeadband(MaxAngularRate * 0.15) // Add a 10% deadband
           .withDriveRequestType(DriveRequestType.OpenLoopVoltage); // We want field-centric driving in open loop
   private final SwerveRequest.SwerveDriveBrake        brake          = new SwerveRequest.SwerveDriveBrake( );
   private final SwerveRequest.FieldCentricFacingAngle facing         = new SwerveRequest.FieldCentricFacingAngle( );

--- a/Comp2024/src/main/java/frc/robot/commands/IntakeActionAcquire.java
+++ b/Comp2024/src/main/java/frc/robot/commands/IntakeActionAcquire.java
@@ -23,13 +23,13 @@ public class IntakeActionAcquire extends SequentialCommandGroup
 
         // @formatter:off
         new PrintCommand(getName() + ": Start rollers & Deploy intake rotary"),
-        new IntakeRun(intake, INConsts.RollerMode.ACQUIRE, INConsts.kRotaryAngleDeployed).asProxy(),
+        new IntakeRun(intake, INConsts.RollerMode.ACQUIRE, INConsts.kRotaryAngleDeployed),
 
         new PrintCommand(getName() + ": Wait for note"),
         new WaitUntilCommand(intake::isNoteDetected),
 
         new PrintCommand(getName() + ": Stop rollers & Retract intake rotary"),
-        new IntakeRun(intake, INConsts.RollerMode.STOP, INConsts.kRotaryAngleRetracted).asProxy()
+        new IntakeRun(intake, INConsts.RollerMode.STOP, INConsts.kRotaryAngleRetracted)
  
         // @formatter:on
     );

--- a/Comp2024/src/main/java/frc/robot/commands/IntakeActionExpel.java
+++ b/Comp2024/src/main/java/frc/robot/commands/IntakeActionExpel.java
@@ -23,16 +23,16 @@ public class IntakeActionExpel extends SequentialCommandGroup
 
         // @formatter:off
         new PrintCommand(getName() + ": Stop rollers & Deploy intake rotary"),
-        new IntakeRun(intake, INConsts.RollerMode.STOP, INConsts.kRotaryAngleDeployed).asProxy(),
+        new IntakeRun(intake, INConsts.RollerMode.STOP, INConsts.kRotaryAngleDeployed),
 
         new PrintCommand(getName() + ": Expel rollers & Hold intake rotary in same position"),        
-        new IntakeRun(intake, INConsts.RollerMode.EXPEL, INConsts.kRotaryAngleDeployed).asProxy(),
+        new IntakeRun(intake, INConsts.RollerMode.EXPEL, INConsts.kRotaryAngleDeployed),
 
         new PrintCommand(getName() + ": Wait for note to release"),
         new WaitCommand(0.5),
 
         new PrintCommand(getName() + ": Stop rollers & Hold intake rotary in same position"),
-        new IntakeRun(intake, INConsts.RollerMode.STOP, INConsts.kRotaryAngleDeployed).asProxy()
+        new IntakeRun(intake, INConsts.RollerMode.STOP, INConsts.kRotaryAngleDeployed)
  
         // @formatter:on
     );

--- a/Comp2024/src/main/java/frc/robot/commands/IntakeActionRetract.java
+++ b/Comp2024/src/main/java/frc/robot/commands/IntakeActionRetract.java
@@ -22,7 +22,7 @@ public class IntakeActionRetract extends SequentialCommandGroup
 
         // @formatter:off
         new PrintCommand(getName() + ": Stop rollers & Retract intake rotary"),
-        new IntakeRun(intake, INConsts.RollerMode.STOP, INConsts.kRotaryAngleRetracted).asProxy()
+        new IntakeRun(intake, INConsts.RollerMode.STOP, INConsts.kRotaryAngleRetracted)
  
         // @formatter:on
     );

--- a/Comp2024/src/main/java/frc/robot/commands/IntakeActionShoot.java
+++ b/Comp2024/src/main/java/frc/robot/commands/IntakeActionShoot.java
@@ -23,16 +23,16 @@ public class IntakeActionShoot extends SequentialCommandGroup
 
         // @formatter:off
         new PrintCommand(getName() + ": Hold rollers & Retract intake rotary"),
-        new IntakeRun(intake, INConsts.RollerMode.HOLD, INConsts.kRotaryAngleRetracted).asProxy(),
+        new IntakeRun(intake, INConsts.RollerMode.HOLD, INConsts.kRotaryAngleRetracted),
 
         new PrintCommand(getName() + ": Expel rollers & Hold intake rotary in same position"),        
-        new IntakeRun(intake, INConsts.RollerMode.EXPEL).asProxy(),
+        new IntakeRun(intake, INConsts.RollerMode.EXPEL),
 
         new PrintCommand(getName() + ": Wait for note to release"),
         new WaitCommand(0.5),
 
         new PrintCommand(getName() + ": Stop rollers & Hold intake rotary in same position"),
-        new IntakeRun(intake, INConsts.RollerMode.HOLD).asProxy()
+        new IntakeRun(intake, INConsts.RollerMode.HOLD)
  
         // @formatter:on
     );

--- a/Comp2024/src/main/java/frc/robot/commands/LEDSet.java
+++ b/Comp2024/src/main/java/frc/robot/commands/LEDSet.java
@@ -3,7 +3,6 @@
 //
 package frc.robot.commands;
 
-import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.LEDConsts.LEDAnimation;
 import frc.robot.Constants.LEDConsts.LEDColor;

--- a/Comp2024/src/main/java/frc/robot/commands/ShooterActionFire.java
+++ b/Comp2024/src/main/java/frc/robot/commands/ShooterActionFire.java
@@ -35,7 +35,7 @@ public class ShooterActionFire extends SequentialCommandGroup
         new PrintCommand(getName() + ": Feed note from intake"),
         new IntakeRun(intake, INConsts.RollerMode.EXPEL, INConsts.kRotaryAngleRetracted),
 
-        new WaitCommand(0.5),
+        new WaitCommand(2.0),
         new ShooterRun(shooter, ShooterMode.STOP),
         new IntakeRun(intake, INConsts.RollerMode.STOP, INConsts.kRotaryAngleRetracted)
 

--- a/Comp2024/src/main/java/frc/robot/commands/ShooterActionFire.java
+++ b/Comp2024/src/main/java/frc/robot/commands/ShooterActionFire.java
@@ -36,8 +36,9 @@ public class ShooterActionFire extends SequentialCommandGroup
         new IntakeRun(intake, INConsts.RollerMode.EXPEL, INConsts.kRotaryAngleRetracted),
 
         new WaitCommand(0.5),
-        new ShooterRun(shooter, ShooterMode.STOP)
- 
+        new ShooterRun(shooter, ShooterMode.STOP),
+        new IntakeRun(intake, INConsts.RollerMode.STOP, INConsts.kRotaryAngleRetracted)
+
         // @formatter:on
     );
   }

--- a/Comp2024/src/main/java/frc/robot/commands/ShooterActionFire.java
+++ b/Comp2024/src/main/java/frc/robot/commands/ShooterActionFire.java
@@ -1,0 +1,50 @@
+
+// ROBOTBUILDER TYPE: SequentialCommandGroup.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.PrintCommand;
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import edu.wpi.first.wpilibj2.command.WaitCommand;
+import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
+import frc.robot.Constants.INConsts;
+import frc.robot.Constants.SHConsts.ShooterMode;
+import frc.robot.subsystems.Intake;
+import frc.robot.subsystems.Shooter;
+
+/**
+ *
+ */
+public class ShooterActionFire extends SequentialCommandGroup
+{
+  public ShooterActionFire(Shooter shooter, Intake intake)
+  {
+    setName("ShooterActionFire");
+
+    addCommands(
+        // Add Commands here:
+
+        // @formatter:off
+        new PrintCommand(getName() + ": Start shooter and retract intake"),
+        new ShooterRun(shooter, ShooterMode.SCORE),
+        new IntakeActionRetract(intake),
+
+        new PrintCommand(getName() + ": Wait for desired speed"),
+        new WaitUntilCommand(shooter::isAtDesiredSpeed),
+
+        new PrintCommand(getName() + ": Feed note from intake"),
+        new IntakeRun(intake, INConsts.RollerMode.EXPEL, INConsts.kRotaryAngleRetracted),
+
+        new WaitCommand(0.5),
+        new ShooterRun(shooter, ShooterMode.STOP)
+ 
+        // @formatter:on
+    );
+  }
+
+  @Override
+  public boolean runsWhenDisabled( )
+  {
+    return false;
+  }
+}

--- a/Comp2024/src/main/java/frc/robot/lib/util/CTREConfigs6.java
+++ b/Comp2024/src/main/java/frc/robot/lib/util/CTREConfigs6.java
@@ -216,7 +216,7 @@ public final class CTREConfigs6
 
   // Climber
 
-  public static TalonFXConfiguration climberLengthFXConfig( )
+  public static TalonFXConfiguration climberFXConfig( )
   {
     TalonFXConfiguration climberConfig = new TalonFXConfiguration( );
 
@@ -225,12 +225,12 @@ public final class CTREConfigs6
     // exConfig.ClosedLoopRamps.*
 
     // Current limit settings
-    climberConfig.CurrentLimits.SupplyCurrentLimit = 20.0;        // Amps
-    climberConfig.CurrentLimits.SupplyCurrentThreshold = 20.0;    // Amps
+    climberConfig.CurrentLimits.SupplyCurrentLimit = 30.0;        // Amps
+    climberConfig.CurrentLimits.SupplyCurrentThreshold = 30.0;    // Amps
     climberConfig.CurrentLimits.SupplyTimeThreshold = 0.001;      // Seconds
     climberConfig.CurrentLimits.SupplyCurrentLimitEnable = true;
 
-    climberConfig.CurrentLimits.StatorCurrentLimit = 45.0;        // Amps
+    climberConfig.CurrentLimits.StatorCurrentLimit = 80.0;        // Amps
     climberConfig.CurrentLimits.StatorCurrentLimitEnable = true;
 
     // Feedback settings

--- a/Comp2024/src/main/java/frc/robot/lib/util/CTREConfigs6.java
+++ b/Comp2024/src/main/java/frc/robot/lib/util/CTREConfigs6.java
@@ -246,7 +246,7 @@ public final class CTREConfigs6
 
     // Motor output settings
     climberConfig.MotorOutput.DutyCycleNeutralDeadband = 0.001;   // Percentage
-    climberConfig.MotorOutput.Inverted = InvertedValue.Clockwise_Positive;
+    climberConfig.MotorOutput.Inverted = InvertedValue.CounterClockwise_Positive;
     climberConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
 
     // Open Loop settings
@@ -262,10 +262,10 @@ public final class CTREConfigs6
     climberConfig.Slot0.kD = 0.0;                                 // Voltage or duty cycle per unit of acceleration error (velocity modes)
 
     // Software limit switches
-    climberConfig.SoftwareLimitSwitch.ReverseSoftLimitThreshold = Conversions.inchesToWinchRotations(0.0, 0.432);   // Rotations
-    climberConfig.SoftwareLimitSwitch.ReverseSoftLimitEnable = true;
-    climberConfig.SoftwareLimitSwitch.ForwardSoftLimitThreshold = Conversions.inchesToWinchRotations(18.25, 0.432); // Rotations
-    climberConfig.SoftwareLimitSwitch.ForwardSoftLimitEnable = true;
+    // climberConfig.SoftwareLimitSwitch.ReverseSoftLimitThreshold = Conversions.inchesToWinchRotations(0.0, 0.432);   // Rotations
+    // climberConfig.SoftwareLimitSwitch.ReverseSoftLimitEnable = true;
+    // climberConfig.SoftwareLimitSwitch.ForwardSoftLimitThreshold = Conversions.inchesToWinchRotations(18.25, 0.432); // Rotations
+    // climberConfig.SoftwareLimitSwitch.ForwardSoftLimitEnable = true;
 
     return climberConfig;
   }

--- a/Comp2024/src/main/java/frc/robot/subsystems/Climber.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Climber.java
@@ -102,9 +102,9 @@ public class Climber extends SubsystemBase
     setName("Climber");
     setSubsystem("Climber");
 
-    m_climberValid = PhoenixUtil6.getInstance( ).talonFXInitialize6(m_climberL, "ClimberL", CTREConfigs6.climberLengthFXConfig( ))
-        && PhoenixUtil6.getInstance( ).talonFXInitialize6(m_climberR, "ClimberR", CTREConfigs6.climberLengthFXConfig( ));
-    m_climberR.setControl(new Follower(m_climberL.getDeviceID( ), false));
+    m_climberValid = PhoenixUtil6.getInstance( ).talonFXInitialize6(m_climberL, "ClimberL", CTREConfigs6.climberFXConfig( ))
+        && PhoenixUtil6.getInstance( ).talonFXInitialize6(m_climberR, "ClimberR", CTREConfigs6.climberFXConfig( ));
+    m_climberR.setControl(new Follower(m_climberL.getDeviceID( ), true));
 
     m_climberL.setPosition(Conversions.inchesToWinchRotations(m_currentInches, kRolloutRatio));
     DataLogManager.log(String.format("%s: CANCoder initial inches %.1f", getSubsystem( ), m_currentInches));

--- a/Comp2024/src/main/java/frc/robot/subsystems/Intake.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Intake.java
@@ -53,7 +53,7 @@ public class Intake extends SubsystemBase
   private static final boolean      kRollerMotorInvert    = true;     // Motor direction for positive input
 
   private static final double       kRollerSpeedAcquire   = 0.5;
-  private static final double       kRollerSpeedExpel     = -0.25;
+  private static final double       kRollerSpeedExpel     = -0.4;
   private static final double       kRollerSpeedToShooter = -0.6;
 
   private static final double       kLigament2dOffset     = 90.0;      // Offset from mechanism root for ligament

--- a/Comp2024/src/main/java/frc/robot/subsystems/Intake.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Intake.java
@@ -63,7 +63,7 @@ public class Intake extends SubsystemBase
   private static final double       kRotaryManualVolts    = 3.5;      // Motor voltage during manual operation (joystick)
 
   // Rotary constants
-  private static final double       kToleranceDegrees     = 2.0;      // PID tolerance in degrees
+  private static final double       kToleranceDegrees     = 5.0;      // PID tolerance in degrees
   private static final double       kMMSafetyTimeout      = 2.0;
 
   // Device and simulation objects

--- a/Comp2024/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Shooter.java
@@ -32,7 +32,7 @@ public class Shooter extends SubsystemBase
   private static final double   kFlywheelGearRatio       = (18.0 / 18.0);
 
   private static final double   kFlywheelToleranceRPM    = 150.0;     // Tolerance band around target RPM
-  private static final double   kFlywheelScoreRPM        = 2150.0;    // RPM to score
+  private static final double   kFlywheelScoreRPM        = 3000.0;    // RPM to score
 
   // Devices and simulation objects
   private final TalonFX         m_shooterLower           = new TalonFX(Ports.kCANID_ShooterLower);

--- a/Comp2024/src/main/java/frc/robot/subsystems/Vision.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Vision.java
@@ -200,4 +200,10 @@ public class Vision extends SubsystemBase
     DataLogManager.log(String.format("%s: setCameraDisplay %d", getSubsystem( ), stream));
     m_table.getEntry("stream").setValue(stream);
   }
+
+  public void setCameraToSecondary( )
+  {
+    DataLogManager.log(String.format("%s: setCameraToSecondary %d", getSubsystem( ), VIConsts.PIP_SECONDARY));
+    m_table.getEntry("stream").setValue(VIConsts.PIP_SECONDARY);
+  }
 }

--- a/Comp2024/src/main/java/frc/robot/subsystems/Vision.java
+++ b/Comp2024/src/main/java/frc/robot/subsystems/Vision.java
@@ -15,6 +15,7 @@ import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.VIConsts;
+import frc.robot.lib.util.LimelightHelpers;
 
 /**
  *
@@ -205,5 +206,6 @@ public class Vision extends SubsystemBase
   {
     DataLogManager.log(String.format("%s: setCameraToSecondary %d", getSubsystem( ), VIConsts.PIP_SECONDARY));
     m_table.getEntry("stream").setValue(VIConsts.PIP_SECONDARY);
+    LimelightHelpers.setStreamMode_PiPSecondary("limelight");
   }
 }


### PR DESCRIPTION
Modified intake target angles to allow commands to reach targets (Falcon sensor does not match CANcoder)
Increased intake tolerance in degrees to allow commands to more easily reach targets
Increased max angular velocity in swerve from 3/4 rotation per sec to 1.5 rot per sec to allow driver to throw out stuck notes
Increased joystick deadband for swerve due to incidences of robot moving after sticks released
Added new shooting sequence to spin up wheels and release note to shooter
Turned on climber default command for manual joystick operation
Removed .asProxy() calls on intake commands to allow IntakeActionRetract to interrupt an ongoing IntakeActionAcquire cmd
Updated climber motor TalonFX configs for correct motor direction and current limits
Increased default shooter speed to 3000 RPM
Increased intake expel speed to more forcefully push into shooter
Added instant command to try to set drive camera display