### PR TITLE
Added tool setting files to .gitignore

### DIFF
--- a/Comp2024/.gitignore
+++ b/Comp2024/.gitignore
@@ -176,3 +176,8 @@ logs/
 
 # Folder that has CTRE Phoenix Sim device config storage
 ctre_sim/
+
+# Tools
+.DataLogTool/
+.OutlineViewer/
+.roboRIOTeamNumberSetter/


### PR DESCRIPTION
These settings files occasionally get checked in by everyone, and this will prevent them from being tracked by git.